### PR TITLE
fix: override URLs only when rawUrl exists to prevent TypeErrors and …

### DIFF
--- a/src/hooks/use-creation.ts
+++ b/src/hooks/use-creation.ts
@@ -14,13 +14,15 @@ export function useCreation(callback: (urls: string[]) => void) {
       let creations = findAllKeysInJson(jsonData, "creations") as Creation[][];
       if (creations.length > 0) {
         const images: string[] = [];
-        creations.forEach((creaetion) => {
-          creaetion.map((item) => {
-            const rawUrl = item.image.image_ori_raw.url;
-            item.image.image_ori.url = rawUrl;
-            item.image.image_preview.url = rawUrl;
-            item.image.image_thumb.url = rawUrl;
-            !images.includes(rawUrl) && images.push(rawUrl);
+        creations.forEach((creation) => {
+          creation.map((item) => {
+            const rawUrl = item?.image?.image_ori_raw?.url;
+            if (rawUrl) {
+              item.image.image_ori && (item.image.image_ori.url = rawUrl);
+              item.image.image_preview && (item.image.image_preview.url = rawUrl);
+              item.image.image_thumb && (item.image.image_thumb.url = rawUrl);
+              !images.includes(rawUrl) && images.push(rawUrl);
+            }
             return item;
           });
         });


### PR DESCRIPTION
较为久远的对话数据里 creations 不存在 image_ori_raw 等字段，导致历史对话加载失败白屏。
仅在 rawUrl 存在时覆盖，避免缺失字段触发 TypeError 。